### PR TITLE
Harden portfolio renderer against missing template title elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
             <section class="tile">
                 <header>
                     <a class="tileButton">
-                        <h3></h3>
+                        <h3 class="tileTitle"></h3>
                         <p class="tileLanguages"></p>
                         <time></time>
                     </a>

--- a/js/main.js
+++ b/js/main.js
@@ -50,6 +50,11 @@ function renderPortfolio() {
         const categoryNode = cloneTemplate('category-template');
         const heading = categoryNode.querySelector('.sectionHeading');
         const tileContainer = categoryNode.querySelector('.tileContainer');
+
+        if (!heading || !tileContainer) {
+            return;
+        }
+
         heading.textContent = category.title;
 
         category.projects.forEach((project) => {
@@ -64,12 +69,22 @@ function renderPortfolio() {
 function buildTile(project) {
     const tile = cloneTemplate('tile-template');
     const button = tile.querySelector('.tileButton');
-    const title = tile.querySelector('h3');
+    let title = tile.querySelector('.tileTitle') || tile.querySelector('h3');
     const languagesLine = tile.querySelector('.tileLanguages');
     const time = tile.querySelector('time');
     const headerNote = tile.querySelector('.tileHeaderNote');
     const contentContainer = tile.querySelector('.tileContent');
     const linkList = tile.querySelector('.tileLinks');
+
+    if (!button || !languagesLine || !time || !headerNote || !contentContainer || !linkList) {
+        return tile;
+    }
+
+    if (!title) {
+        title = document.createElement('h3');
+        title.classList.add('tileTitle');
+        button.prepend(title);
+    }
 
     if (project.fullRow) {
         tile.classList.add('fullRow');


### PR DESCRIPTION
### Motivation
- Fix a runtime `TypeError: can't access property "textContent", title is null` that occurs when a tile template is missing expected elements, causing the portfolio render to fail.
- Make the renderer resilient to small template changes or malformed clones so the rest of the page still renders.

### Description
- Add a defensive check in `renderPortfolio` to skip category template clones that lack a `.sectionHeading` or `.tileContainer` instead of throwing. 
- Update `buildTile` to prefer a `.tileTitle` selector, fall back to `h3`, and create a `h3.tileTitle` element when the title is missing before assigning `textContent`.
- Return the cloned tile early when other required child nodes are missing to avoid further errors. 
- Add the `.tileTitle` class to the tile heading in `index.html` so title lookup is explicit and stable.

### Testing
- Ran `node --check js/main.js` and it succeeded with no syntax errors. 
- Served the site locally with `python3 -m http.server 4173` and validated rendering with an automated Playwright script that opened `http://127.0.0.1:4173`, observed no console/page errors, and captured a full-page screenshot (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e4d73c06c832e99d0df2f118bb89a)